### PR TITLE
Update amount input type.

### DIFF
--- a/views/pay-now-form.php
+++ b/views/pay-now-form.php
@@ -50,7 +50,7 @@
     <?php if ( empty( $atts['amount'] ) ) : ?>
 
       <label class="pay-now"><?php _e( 'Amount', 'rave-pay' ); ?></label>
-      <input class="flw-form-input-text" id="flw-amount" type="text" placeholder="<?php _e( 'Amount', 'rave-pay' ); ?>" required /><br>
+      <input class="flw-form-input-text" id="flw-amount" type="number" placeholder="<?php _e( 'Amount', 'rave-pay' ); ?>" required /><br>
 
     <?php endif; ?>
 


### PR DESCRIPTION
Users can inadvertently input letters in the amount box. The page submits value 0 as the amount when such happens. Changing the input type to 'number' helps avoid that.